### PR TITLE
Node expansion fix

### DIFF
--- a/src/gtknode.c
+++ b/src/gtknode.c
@@ -1745,7 +1745,7 @@ gtk_nodes_node_get_expanded (GtkNodesNode *node)
  */
 
 void
-gtk_nodes_node_set_expaned (GtkNodesNode *node,
+gtk_nodes_node_set_expanded (GtkNodesNode *node,
                             gboolean expanded)
 {
   GtkNodesNodePrivate *priv;


### PR DESCRIPTION
Very minor change, but this fixes a bug that was preventing me from being able to programmatically expanding/collapsing node widgets. I've tested both of the included examples with the change.