### PR TITLE
Fix Python run instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ make sure to export the proper paths, i.e. from the examples/ subdirectory
 run the demo like this:
 
 ```
-GI_TYPELIB_PATH=../src/ LD_LIBRARY_PATH=../src/.libs python img.py
+GI_TYPELIB_PATH=../introspection/ LD_LIBRARY_PATH=../src/.libs python img.py
 ```
 
 


### PR DESCRIPTION
Thanks for writing this library!

The script given in `README` is broken, `GI_TYPELIB_PATH` needs to point to the `introspection` folder for it to work, at least in my build environment.